### PR TITLE
Allow opening other files in a commit from the commit changes window

### DIFF
--- a/GitTimelapseView/Components/CommitInfo/CommitInfo.razor
+++ b/GitTimelapseView/Components/CommitInfo/CommitInfo.razor
@@ -66,7 +66,7 @@ else
     MessageService MessageService { get; set; } = default!;
 
     private Commit? _commit;
-    string _selectedTab = "message";
+    static string _selectedTab = "message";
     private string _authoredString => _commit?.Author.When.ToString("dd/MM/yyyy @ hh:mm") ?? string.Empty;
     private const string CopyToClipboardTooltip = "Copy complete id to clipboard";
 

--- a/GitTimelapseView/Components/CommitInfo/CommitInfo.razor
+++ b/GitTimelapseView/Components/CommitInfo/CommitInfo.razor
@@ -43,7 +43,7 @@ else
                 }
         </Extra>
         <CardTabs>
-	        <Tabs @bind-ActiveKey="@_selectedTab" Animated Size="@TabSize.Small" >
+	        <Tabs @bind-ActiveKey="@TimelapseService.CommitInfoSelectedTab" Animated Size="@TabSize.Small" >
 			    <TabPane Tab="Message" Key="message">
                     <div class="commit-message">
 				        @_commit.Message
@@ -66,7 +66,6 @@ else
     MessageService MessageService { get; set; } = default!;
 
     private Commit? _commit;
-    static string _selectedTab = "message";
     private string _authoredString => _commit?.Author.When.ToString("dd/MM/yyyy @ hh:mm") ?? string.Empty;
     private const string CopyToClipboardTooltip = "Copy complete id to clipboard";
 

--- a/GitTimelapseView/Components/CommitInfo/FileChanges.razor
+++ b/GitTimelapseView/Components/CommitInfo/FileChanges.razor
@@ -65,7 +65,7 @@
 
     public void OnPathClicked(FileChangeTableRow fileChangeRow)
     {
-        new OpenFileAction(fileChangeRow.Path, null, null, fileChangeRow.FileChange.Commit.Id).ExecuteAsync().ConfigureAwait(false);
+        new OpenFileAction(fileChangeRow.Path, revisionSha: fileChangeRow.FileChange.Commit.Id).ExecuteAsync().ConfigureAwait(false);
     }
 
     public class FileChangeTableRow

--- a/GitTimelapseView/Components/CommitInfo/FileChanges.razor
+++ b/GitTimelapseView/Components/CommitInfo/FileChanges.razor
@@ -27,7 +27,9 @@
 			<i class="mdi mdi-alpha-c-box change-icon" style="color: red;" title="Conflict"></i>
 		}
     </Column>
-    <Column @bind-Field="@context.Path" Title="Path" Width="520" Ellipsis Sortable Filterable />
+    <Column @bind-Field="@context.Path" Title="Path" Width="520" Ellipsis Sortable Filterable>
+        <Button Type="@ButtonType.Link" OnClick="()=>OnPathClicked(context)" Size="@ButtonSize.Small">@context.Path</Button>
+    </Column>
     <ActionColumn Width="60">
         <div class="actions">
             <Tooltip Title="@DiffTooltip">
@@ -59,6 +61,11 @@
     public void OnRowClicked(FileChangeTableRow fileChangeRow)
     {
         new DiffFileChangeAction(fileChangeRow.FileChange, CommitId).ExecuteAsync().ConfigureAwait(false);
+    }
+
+    public void OnPathClicked(FileChangeTableRow fileChangeRow)
+    {
+        new OpenFileAction(fileChangeRow.Path, null, null, fileChangeRow.FileChange.Commit.Id).ExecuteAsync().ConfigureAwait(false);
     }
 
     public class FileChangeTableRow

--- a/GitTimelapseView/Components/Editor/TextEditor.razor
+++ b/GitTimelapseView/Components/Editor/TextEditor.razor
@@ -89,7 +89,7 @@
         {
             try
             {
-                _model = await MonacoEditor.CreateModel(newValue, null, TimelapseService.FilePath);
+                _model = await MonacoEditor.CreateModel(newValue, null, null);
                 await _editor.SetModel(_model);
                 if (TimelapseService.InitialLineNumber != null)
                 {

--- a/GitTimelapseView/Services/TimelapseService.cs
+++ b/GitTimelapseView/Services/TimelapseService.cs
@@ -16,6 +16,7 @@ namespace GitTimelapseView.Services
         public TimelapseService(ILoggerFactory loggerFactory)
             : base(loggerFactory)
         {
+            CommitInfoSelectedTab = "message";
         }
 
         public event EventHandler<string>? FileLoading;
@@ -53,6 +54,8 @@ namespace GitTimelapseView.Services
         }
 
         public int? InitialLineNumber { get; set; }
+
+        public string CommitInfoSelectedTab { get; set; }
 
         public async Task OpenFileAsync(ILogger logger, string filePath, int? lineNumber, int? revisionIndex, string? revisionSha)
         {


### PR DESCRIPTION
This changes the files listed in the commit changes window to links which will open the revision of the file in the same commit.

The change of `_selectedTab` to a `static` seemed the most pragmatic option for preserving the same selected tab when the components are recreated, otherwise it resets back to the message window. My knowledge of ASP.NET, Razor, etc is very limited, so if there's a preferred way to preserve this state then I'm all ears. But this appeared to be reasonable short of adding a whole load of extra state management.

The change of the model uid in `TextEditor.razor` is due to an issue I uncovered while testing this, although it doesn't appear to be unique to this change. Originally, the model id was the path of the file being opened. If we go back and forth between opening the same set of files repeatedly (which is much easier to do quickly with this change), Monaco will eventually throw an exception in the `CreateModel` call if the old model has not been disposed of in time, since the same ID is attempted to be used. Passing null causes it to generate it's own model ID, which appears to be fine. Again, not much experience here so if there's a preferable alternative, or you'd like this in it's own separate change, please do say!



https://github.com/user-attachments/assets/e6c20f3f-d15f-450e-88cd-470d9fc9385d

